### PR TITLE
Use tree walking and polling for Github buttons

### DIFF
--- a/ext/src/content/content.js
+++ b/ext/src/content/content.js
@@ -2,7 +2,7 @@
 
 function init() {
   const GITHUB_URL = "https://github.com";
-  const GITHUB_VALID_PATHNAMES = /^\/.*\/.*\/(?:pull\/\d+(?:\/?|\/files\/?)$|commit|issues\/\d+|issues\/new)/u;
+  const GITHUB_VALID_PATHNAMES = /^\/.*\/.*\/(?:pull\/\d+(?:\/?|\/files\/?)$|commit|compare\/.*|issues\/\d+|issues\/new)/u;
   const GITHUB_POLLING_TIME_IN_SECONDS = 1;
   let isGithubListenerAdded = false;
 
@@ -31,28 +31,31 @@ function init() {
       button.style[key] = value;
     }
 
-    if (append) {
-      el.append(button);
-    } 
-
     if (refNode){
       el.insertBefore(button, refNode);
+    }else if(append){
+      el.append(button);
+    }else{
+      el.prepend(button);
     }
 
     return button;
   }
 
   function discoverButtonsAndCreatePrettierButtons(){
-    const COMMENT_BUTTON_TEXT = 'Comment';
-    const ISSUE_BUTTON_TEXT = 'Submit new issue';
+    const COMMENT = 'Comment';
+    const SUBMIT_PULL_REQUEST = 'Create pull request';
+    const SUBMIT_NEW_ISSUE = 'Submit new issue';
+
+    const BUTTONS_WITH_STYLING = [SUBMIT_PULL_REQUEST, SUBMIT_NEW_ISSUE]
+    const BUTTONS_TO_SEARCH_FOR = [COMMENT, SUBMIT_PULL_REQUEST, SUBMIT_NEW_ISSUE]
     const buttons = document.getElementsByTagName('button');
     
     for(const button of buttons){
-      if(button.innerText === COMMENT_BUTTON_TEXT ||
-         button.innerText === ISSUE_BUTTON_TEXT){
+      if(BUTTONS_TO_SEARCH_FOR.includes(button.innerText)){
         if(button.parentNode.querySelector('.prettier-btn') === null){
-          const refNode = button.innerText === ISSUE_BUTTON_TEXT ? button : null;
-          const style = button.innerText === ISSUE_BUTTON_TEXT ? { 'margin-right': '5px' } : {};
+          const refNode = BUTTONS_WITH_STYLING.includes(button.innerText) ? button : null;
+          const style = BUTTONS_WITH_STYLING.includes(button.innerText) ? { 'margin-right': '5px', 'float': 'left' } : {};
 
           const buttonElem = renderButton(button.parentNode, { classes: ['prettier-btn'], append: true, style, refNode });
           const textArea = findTextArea(buttonElem);

--- a/ext/src/content/content.js
+++ b/ext/src/content/content.js
@@ -55,6 +55,7 @@ function init() {
   }
 
   function searchAndAddListenerToButtons() {
+    const COMMENT = "Comment";
     const REPLY = "Reply…";
     const CANCEL = "Cancel";
     const CLOSE_ISSUE = " Close issue";
@@ -62,6 +63,7 @@ function init() {
     const SUBMIT_PULL_REQUEST = "Create pull request";
     const SUBMIT_NEW_ISSUE = "Submit new issue";
     const BUTTONS_TO_SEARCH_FOR = [
+      COMMENT,
       CANCEL,
       CLOSE_ISSUE,
       CLOSE_PULL_REQUEST,
@@ -73,6 +75,17 @@ function init() {
     const createList = [];
     for (const button of buttons) {
       if (BUTTONS_TO_SEARCH_FOR.includes(button.innerText)) {
+        if (
+          button.innerText === COMMENT &&
+          (button.parentNode.parentNode.querySelector(
+            "button[name=comment_and_close]"
+          ) ||
+            button.parentNode.parentNode.querySelector(
+              "button[data-confirm-cancel-text]"
+            ))
+        ) {
+          continue;
+        }
         createList.push(button);
       }
       if (button.innerText === REPLY) {

--- a/ext/src/content/content.js
+++ b/ext/src/content/content.js
@@ -44,6 +44,16 @@ function init() {
     return button;
   }
 
+  function setupCommentObserver(observer) {
+    for (const elem of document.querySelectorAll(".timeline-comment-group")) {
+      observer.observe(elem, {
+        attributes: true,
+        childList: true,
+        subtree: true
+      });
+    }
+  }
+
   function searchAndAddListenerToButtons() {
     const COMMENT = "Comment";
     const REPLY = "Reply…";
@@ -320,13 +330,19 @@ function init() {
   if (window.location.origin === GITHUB_URL) {
     let currentPath = window.location.pathname;
     if (!isGithubListenerAdded) {
-      const observer = new MutationObserver(() => {
+      const commentObserver = new MutationObserver(() => {
+        initGitHubButton();
+      });
+      const pageObserver = new MutationObserver(() => {
         if (window.location.pathname !== currentPath) {
           currentPath = window.location.pathname;
           initGitHubButton();
+          commentObserver.disconnect();
+          setupCommentObserver(commentObserver);
         }
       });
-      observer.observe(document.querySelector("body"), { childList: true });
+      pageObserver.observe(document.querySelector("body"), { childList: true });
+      setupCommentObserver(commentObserver);
       isGithubListenerAdded = true;
     }
     initGitHubButton();

--- a/ext/src/content/content.js
+++ b/ext/src/content/content.js
@@ -3,8 +3,6 @@
 function init() {
   const GITHUB_URL = "https://github.com";
   const GITHUB_VALID_PATHNAMES = /^\/.*\/.*\/(?:pull\/\d+(?:\/?|\/files\/?)$|commit|compare\/.*|issues\/\d+|issues\/new)/u;
-  const ONE_SECOND_IN_MILLISECONDS = 1000;
-  const GITHUB_POLLING_TIME_IN_SECONDS = 1 * ONE_SECOND_IN_MILLISECONDS;
   let isGithubListenerAdded = false;
 
   const STACKOVERFLOW_URL = "https://stackoverflow.com";
@@ -46,68 +44,90 @@ function init() {
     return button;
   }
 
-  function discoverButtonsAndCreatePrettierButtons() {
+  function searchAndAddListenerToButtons() {
     const COMMENT = "Comment";
     const REPLY = "Reply…";
+    const CANCEL = "Cancel";
+    const CLOSE_PULL_REQUEST = " Close pull request";
     const SUBMIT_PULL_REQUEST = "Create pull request";
     const SUBMIT_NEW_ISSUE = "Submit new issue";
-
-    const BUTTONS_WITH_STYLING = [SUBMIT_PULL_REQUEST, SUBMIT_NEW_ISSUE];
     const BUTTONS_TO_SEARCH_FOR = [
       COMMENT,
+      CANCEL,
+      CLOSE_PULL_REQUEST,
       SUBMIT_PULL_REQUEST,
       SUBMIT_NEW_ISSUE
     ];
-    const buttons = document.getElementsByTagName("button");
 
+    const buttons = document.getElementsByTagName("button");
+    const createList = [];
     for (const button of buttons) {
       if (BUTTONS_TO_SEARCH_FOR.includes(button.innerText)) {
-        if (button.parentNode.querySelector(".prettier-btn") === null) {
-          const refNode = BUTTONS_WITH_STYLING.includes(button.innerText)
-            ? button
-            : null;
-          const style = BUTTONS_WITH_STYLING.includes(button.innerText)
-            ? { float: "left", "margin-right": "5px" }
-            : {};
-
-          const buttonElem = renderButton(button.parentNode, {
-            append: true,
-            classes: ["prettier-btn"],
-            refNode,
-            style
-          });
-          const textArea = findTextArea(buttonElem);
-          buttonElem.addEventListener("click", event => {
-            event.preventDefault();
-            textArea.value = window.prettier.format(textArea.value, {
-              parser: "markdown",
-              plugins: window.prettierPlugins
-            });
-            textArea.focus();
-          });
+        if (
+          button.innerText === COMMENT &&
+          (button.parentNode.parentNode.querySelector(
+            "button[name=comment_and_close]"
+          ) ||
+            button.parentNode.parentNode.querySelector(
+              "button[data-confirm-cancel-text]"
+            ))
+        ) {
+          continue;
         }
+        createList.push(button);
       }
       if (button.innerText === REPLY) {
-        button.addEventListener("click", () => {
-          window.setTimeout(
-            discoverButtonsAndCreatePrettierButtons,
-            ONE_SECOND_IN_MILLISECONDS
-          );
+        const observer = new MutationObserver(() => {
+          discoverButtonsAndCreatePrettierButtons();
+        });
+        observer.observe(
+          findWithClass(button, "inline-comment-form-container"),
+          { attributes: true }
+        );
+      }
+    }
+    return createList;
+  }
+
+  function discoverButtonsAndCreatePrettierButtons() {
+    const BUTTON_STYLE = { float: "left", "margin-right": "10px" };
+    const createList = searchAndAddListenerToButtons();
+
+    for (const button of createList) {
+      if (button.parentNode.querySelector(".prettier-btn") === null) {
+        const buttonElem = renderButton(button.parentNode, {
+          append: true,
+          classes: ["prettier-btn"],
+          refNode: button,
+          style: BUTTON_STYLE
+        });
+        const textArea = findWithClass(buttonElem, "comment-form-textarea");
+        buttonElem.addEventListener("click", event => {
+          event.preventDefault();
+          textArea.value = window.prettier.format(textArea.value, {
+            parser: "markdown",
+            plugins: window.prettierPlugins
+          });
+          textArea.focus();
         });
       }
     }
   }
 
-  function findTextArea(buttonElement) {
+  function findWithClass(buttonElement, classToFind) {
     const alreadySeen = [];
     const alreadyAdded = [];
     const childrenNodes = [buttonElement];
 
     while (childrenNodes.length > 0) {
       const thisChild = childrenNodes.pop();
+      const classList = thisChild.classList
+        ? Array.from(thisChild.classList)
+        : [];
+
       if (
         thisChild.tagName &&
-        thisChild.tagName !== "TEXTAREA" &&
+        !classList.includes(classToFind) &&
         !alreadySeen.includes(thisChild)
       ) {
         if (!alreadyAdded.includes(thisChild.parentNode)) {
@@ -118,7 +138,7 @@ function init() {
         childrenNodes.push(...thisChild.childNodes);
       }
 
-      if (thisChild.tagName === "TEXTAREA") {
+      if (classList.includes(classToFind)) {
         return thisChild;
       }
     }
@@ -300,12 +320,13 @@ function init() {
   if (window.location.origin === GITHUB_URL) {
     let currentPath = window.location.pathname;
     if (!isGithubListenerAdded) {
-      window.setInterval(() => {
+      const observer = new MutationObserver(() => {
         if (window.location.pathname !== currentPath) {
           currentPath = window.location.pathname;
-          setTimeout(initGitHubButton, ONE_SECOND_IN_MILLISECONDS);
+          initGitHubButton();
         }
-      }, GITHUB_POLLING_TIME_IN_SECONDS);
+      });
+      observer.observe(document.querySelector("body"), { childList: true });
       isGithubListenerAdded = true;
     }
     initGitHubButton();

--- a/ext/src/content/content.js
+++ b/ext/src/content/content.js
@@ -58,12 +58,13 @@ function init() {
     const COMMENT = "Comment";
     const REPLY = "Reply…";
     const CANCEL = "Cancel";
+    const CLOSE_ISSUE = " Close issue";
     const CLOSE_PULL_REQUEST = " Close pull request";
     const SUBMIT_PULL_REQUEST = "Create pull request";
     const SUBMIT_NEW_ISSUE = "Submit new issue";
     const BUTTONS_TO_SEARCH_FOR = [
-      COMMENT,
       CANCEL,
+      CLOSE_ISSUE,
       CLOSE_PULL_REQUEST,
       SUBMIT_PULL_REQUEST,
       SUBMIT_NEW_ISSUE
@@ -73,17 +74,6 @@ function init() {
     const createList = [];
     for (const button of buttons) {
       if (BUTTONS_TO_SEARCH_FOR.includes(button.innerText)) {
-        if (
-          button.innerText === COMMENT &&
-          (button.parentNode.parentNode.querySelector(
-            "button[name=comment_and_close]"
-          ) ||
-            button.parentNode.parentNode.querySelector(
-              "button[data-confirm-cancel-text]"
-            ))
-        ) {
-          continue;
-        }
         createList.push(button);
       }
       if (button.innerText === REPLY) {
@@ -333,15 +323,30 @@ function init() {
       const commentObserver = new MutationObserver(() => {
         initGitHubButton();
       });
+      const newCommentObserver = new MutationObserver(() => {
+        commentObserver.disconnect();
+        setupCommentObserver(commentObserver);
+      });
       const pageObserver = new MutationObserver(() => {
         if (window.location.pathname !== currentPath) {
           currentPath = window.location.pathname;
           initGitHubButton();
+
           commentObserver.disconnect();
           setupCommentObserver(commentObserver);
+          const content = document.querySelector(".js-disscussion");
+          if (content) {
+            newCommentObserver.disconnect();
+            newCommentObserver.observe(content, { childList: true });
+          }
         }
       });
-      pageObserver.observe(document.querySelector("body"), { childList: true });
+      pageObserver.observe(document.querySelector("body"), {
+        childList: true
+      });
+      newCommentObserver.observe(document.querySelector(".js-discussion"), {
+        childList: true
+      });
       setupCommentObserver(commentObserver);
       isGithubListenerAdded = true;
     }

--- a/ext/src/content/content.js
+++ b/ext/src/content/content.js
@@ -3,7 +3,8 @@
 function init() {
   const GITHUB_URL = "https://github.com";
   const GITHUB_VALID_PATHNAMES = /^\/.*\/.*\/(?:pull\/\d+(?:\/?|\/files\/?)$|commit|compare\/.*|issues\/\d+|issues\/new)/u;
-  const GITHUB_POLLING_TIME_IN_SECONDS = 1;
+  const ONE_SECOND_IN_MILLISECONDS = 1000;
+  const GITHUB_POLLING_TIME_IN_SECONDS = 1 * ONE_SECOND_IN_MILLISECONDS;
   let isGithubListenerAdded = false;
 
   const STACKOVERFLOW_URL = "https://stackoverflow.com";
@@ -22,7 +23,10 @@ function init() {
     yaml: "yaml"
   };
 
-  function renderButton(el, { classes = [], style = {}, append = true, refNode = null } = {}) {
+  function renderButton(
+    el,
+    { classes = [], style = {}, append = true, refNode = null } = {}
+  ) {
     const button = document.createElement("button");
     button.textContent = "Prettier";
     button.classList.add("btn", ...classes);
@@ -31,33 +35,47 @@ function init() {
       button.style[key] = value;
     }
 
-    if (refNode){
+    if (refNode) {
       el.insertBefore(button, refNode);
-    }else if(append){
+    } else if (append) {
       el.append(button);
-    }else{
+    } else {
       el.prepend(button);
     }
 
     return button;
   }
 
-  function discoverButtonsAndCreatePrettierButtons(){
-    const COMMENT = 'Comment';
-    const SUBMIT_PULL_REQUEST = 'Create pull request';
-    const SUBMIT_NEW_ISSUE = 'Submit new issue';
+  function discoverButtonsAndCreatePrettierButtons() {
+    const COMMENT = "Comment";
+    const REPLY = "Reply…";
+    const SUBMIT_PULL_REQUEST = "Create pull request";
+    const SUBMIT_NEW_ISSUE = "Submit new issue";
 
-    const BUTTONS_WITH_STYLING = [SUBMIT_PULL_REQUEST, SUBMIT_NEW_ISSUE]
-    const BUTTONS_TO_SEARCH_FOR = [COMMENT, SUBMIT_PULL_REQUEST, SUBMIT_NEW_ISSUE]
-    const buttons = document.getElementsByTagName('button');
-    
-    for(const button of buttons){
-      if(BUTTONS_TO_SEARCH_FOR.includes(button.innerText)){
-        if(button.parentNode.querySelector('.prettier-btn') === null){
-          const refNode = BUTTONS_WITH_STYLING.includes(button.innerText) ? button : null;
-          const style = BUTTONS_WITH_STYLING.includes(button.innerText) ? { 'margin-right': '5px', 'float': 'left' } : {};
+    const BUTTONS_WITH_STYLING = [SUBMIT_PULL_REQUEST, SUBMIT_NEW_ISSUE];
+    const BUTTONS_TO_SEARCH_FOR = [
+      COMMENT,
+      SUBMIT_PULL_REQUEST,
+      SUBMIT_NEW_ISSUE
+    ];
+    const buttons = document.getElementsByTagName("button");
 
-          const buttonElem = renderButton(button.parentNode, { classes: ['prettier-btn'], append: true, style, refNode });
+    for (const button of buttons) {
+      if (BUTTONS_TO_SEARCH_FOR.includes(button.innerText)) {
+        if (button.parentNode.querySelector(".prettier-btn") === null) {
+          const refNode = BUTTONS_WITH_STYLING.includes(button.innerText)
+            ? button
+            : null;
+          const style = BUTTONS_WITH_STYLING.includes(button.innerText)
+            ? { float: "left", "margin-right": "5px" }
+            : {};
+
+          const buttonElem = renderButton(button.parentNode, {
+            append: true,
+            classes: ["prettier-btn"],
+            refNode,
+            style
+          });
           const textArea = findTextArea(buttonElem);
           buttonElem.addEventListener("click", event => {
             event.preventDefault();
@@ -69,25 +87,30 @@ function init() {
           });
         }
       }
-      if(button.innerText === 'Reply…'){
-        button.addEventListener('click', () => {
-          window.setTimeout(discoverButtonsAndCreatePrettierButtons, 100);
+      if (button.innerText === REPLY) {
+        button.addEventListener("click", () => {
+          window.setTimeout(
+            discoverButtonsAndCreatePrettierButtons,
+            ONE_SECOND_IN_MILLISECONDS
+          );
         });
       }
     }
   }
 
-  function findTextArea(buttonElement){
+  function findTextArea(buttonElement) {
     const alreadySeen = [];
     const alreadyAdded = [];
     const childrenNodes = [buttonElement];
 
-    while(childrenNodes.length > 0){
+    while (childrenNodes.length > 0) {
       const thisChild = childrenNodes.pop();
-      if(thisChild.tagName &&
-         thisChild.tagName !== 'TEXTAREA' &&
-         !alreadySeen.includes(thisChild)){
-        if(!alreadyAdded.includes(thisChild.parentNode)){
+      if (
+        thisChild.tagName &&
+        thisChild.tagName !== "TEXTAREA" &&
+        !alreadySeen.includes(thisChild)
+      ) {
+        if (!alreadyAdded.includes(thisChild.parentNode)) {
           childrenNodes.push(thisChild.parentNode);
           alreadyAdded.push(thisChild.parentNode);
         }
@@ -95,7 +118,7 @@ function init() {
         childrenNodes.push(...thisChild.childNodes);
       }
 
-      if(thisChild.tagName === 'TEXTAREA'){
+      if (thisChild.tagName === "TEXTAREA") {
         return thisChild;
       }
     }
@@ -111,7 +134,7 @@ function init() {
    * 3. Issues
    */
   function initGitHubButton() {
-    if(GITHUB_VALID_PATHNAMES.test(window.location.pathname)){
+    if (GITHUB_VALID_PATHNAMES.test(window.location.pathname)) {
       discoverButtonsAndCreatePrettierButtons();
     }
   }
@@ -274,15 +297,15 @@ function init() {
     }, POLLING_INTERVAL);
   }
 
-  if(window.location.origin === GITHUB_URL){
+  if (window.location.origin === GITHUB_URL) {
     let currentPath = window.location.pathname;
-    if(!isGithubListenerAdded){
+    if (!isGithubListenerAdded) {
       window.setInterval(() => {
-        if(window.location.pathname !== currentPath){
-          currentPath = window.location.pathname
-          setTimeout(initGitHubButton, 1000);
+        if (window.location.pathname !== currentPath) {
+          currentPath = window.location.pathname;
+          setTimeout(initGitHubButton, ONE_SECOND_IN_MILLISECONDS);
         }
-      }, GITHUB_POLLING_TIME_IN_SECONDS * 1000);
+      }, GITHUB_POLLING_TIME_IN_SECONDS);
       isGithubListenerAdded = true;
     }
     initGitHubButton();

--- a/ext/src/content/content.js
+++ b/ext/src/content/content.js
@@ -108,7 +108,7 @@ function init() {
    *
    * 1. Pull request conversation view
    * 2. Pull request diff view
-   * 3. Issues (still needs to be implemented)
+   * 3. Issues
    */
   function initGitHubButton() {
     if(GITHUB_VALID_PATHNAMES.test(window.location.pathname)){

--- a/ext/src/content/content.js
+++ b/ext/src/content/content.js
@@ -55,7 +55,6 @@ function init() {
   }
 
   function searchAndAddListenerToButtons() {
-    const COMMENT = "Comment";
     const REPLY = "Reply…";
     const CANCEL = "Cancel";
     const CLOSE_ISSUE = " Close issue";


### PR DESCRIPTION
This pull request is to address the following issues:
#15 
#14 

What does this change do?
- Uses tree walking to find text-area's 
  - First we find all the buttons we want to create 'Prettier' buttons next to and create them. Once we have done that we then do a tree walk from that button upwards until we find the first text area.
- Added buttons to Issues

I've tested this in most cases I think of with no issues found.
- New PR's
- New Issues
- Issue comments
- PR comments (as well as comments on diffs)

The only thing that might want tweaking is the Polling timer I've setup, I've set it to a second as realistically the check that I'm doing to see if the path name has changed is extremely light-weight but we could change it to something like five seconds if you don't mind the buttons appearing slightly later.