### PR TITLE
Maintain Browser history on 'Prettier' + Fix issue with button on appearing on 'Create pull Request'

### DIFF
--- a/ext/src/content/content.js
+++ b/ext/src/content/content.js
@@ -116,11 +116,14 @@ function init() {
         const textArea = findWithClass(buttonElem, "comment-form-textarea");
         buttonElem.addEventListener("click", event => {
           event.preventDefault();
-          textArea.value = window.prettier.format(textArea.value, {
+          const formattedText = window.prettier.format(textArea.value, {
             parser: "markdown",
             plugins: window.prettierPlugins
           });
           textArea.focus();
+          textArea.select();
+          document.execCommand("delete", false, null);
+          document.execCommand("insertText", false, formattedText);
         });
       }
     }
@@ -356,9 +359,12 @@ function init() {
       pageObserver.observe(document.querySelector("body"), {
         childList: true
       });
-      newCommentObserver.observe(document.querySelector(".js-discussion"), {
-        childList: true
-      });
+      const jsDiscussion = document.querySelector(".js-discussion");
+      if (jsDiscussion) {
+        newCommentObserver.observe(jsDiscussion, {
+          childList: true
+        });
+      }
       setupCommentObserver(commentObserver);
       isGithubListenerAdded = true;
     }


### PR DESCRIPTION
This PR is to address the issue raised in:
#22 

This was fixed by switching to document.execCommand to insert the text into the textarea, which allows the browser to continue to keep track of history -> We should probably use this as the standard way of modifying text rather than setting the value.

Along with a small bugfix to check for the existence of the 'js-discussion' element before trying to observe it. (This was causing the 'Prettier' button to not render on the Create pull request pages)

Let me know if you have any questions or concerns.
