### PR TITLE
Fix: formatting of code blocks in Stack Overflow

### DIFF
--- a/ext/src/content/content.js
+++ b/ext/src/content/content.js
@@ -353,7 +353,7 @@ function init() {
               let codeLines;
 
               if (isCodeBlock) {
-                codeLines = codeLines.slice(1, -1);
+                codeLines = lines.slice(1, -1);
               } else {
                 const indentedLineCodeBlockStartIdx = 2;
                 codeLines = isIndentedBlockWithLang


### PR DESCRIPTION
I'm not sure how I missed this, but this fixes the formatting of code blocks in Stack Overflow.