### PR TITLE
Chore: minify bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-extension.zip
-extension/dist
 node_modules
+extension/dist
+extension.zip

--- a/extension/src/content/index.js
+++ b/extension/src/content/index.js
@@ -1,8 +1,5 @@
-import parserAngular from "prettier/parser-angular";
 import parserBabylon from "prettier/parser-babylon";
 import parserFlow from "prettier/parser-flow";
-import parserGlimmer from "prettier/parser-glimmer";
-import parserGraphql from "prettier/parser-graphql";
 import parserHtml from "prettier/parser-html";
 import parserMarkdown from "prettier/parser-markdown";
 import parserPostcss from "prettier/parser-postcss";
@@ -12,11 +9,8 @@ import prettier from "prettier/standalone";
 
 function init() {
   const prettierPlugins = [
-    parserAngular,
     parserBabylon,
     parserFlow,
-    parserGlimmer,
-    parserGraphql,
     parserHtml,
     parserMarkdown,
     parserPostcss,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,22 @@
 const path = require("path");
+const TerserPlugin = require("terser-webpack-plugin"); // included as a dependency of webpack
 
 module.exports = {
   entry: "./extension/src/content/index.js",
+  mode: "production",
+  optimization: {
+    minimize: true,
+    minimizer: [
+      new TerserPlugin({
+        terserOptions: {
+          extractComments: false,
+
+          // https://github.com/webpack-contrib/terser-webpack-plugin/issues/107
+          output: { ascii_only: true }
+        }
+      })
+    ]
+  },
   output: {
     filename: "main.js",
     path: path.resolve(__dirname, "extension/dist")


### PR DESCRIPTION
`terser-webpack-plugin` is the default minification plugin and is already included as a dependency of webpack. Generally, I advocate for explicitly listing dependencies, but in this case, I think it makes sense to make sure we're using the version installed by webpack.