### PR TITLE
Fix: fix css parser warning in console

### DIFF
--- a/extension/src/content/index.js
+++ b/extension/src/content/index.js
@@ -26,13 +26,14 @@ function init() {
   const STACKOVERFLOW_URL = "https://stackoverflow.com";
   const STACKOVERFLOW_VALID_PATHNAMES = /^\/questions/u;
   const PARSERS_LANG_MAP = {
-    css: "postcss",
+    css: "css",
     flow: "flow",
     html: "html",
     javascript: "babel",
     js: "babel",
     json: "babel",
     less: "postcss",
+    sass: "postcss",
     scss: "postcss",
     ts: "typescript",
     typescript: "typescript",


### PR DESCRIPTION
<img width="678" alt="Screen Shot 2019-10-16 at 1 10 14 AM" src="https://user-images.githubusercontent.com/7041728/66889813-c8492f00-efb1-11e9-82d9-759f98a1fc62.png">

This PR gets rid of this warning and adds a new mapping for `lang-sass` (in addition to `lang-scss` for Stack Overflow.
