### PR TITLE
Chore: lock all package versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "eslint-plugin-prettier": "3.1.1",
     "husky": "3.0.8",
     "lint-staged": "9.4.2",
-    "webpack": "^4.41.1",
-    "webpack-cli": "^3.3.9"
+    "webpack": "4.41.1",
+    "webpack-cli": "3.3.9"
   },
   "lint-staged": {
     "*.{js}": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4036,7 +4036,7 @@ watchpack@^1.6.0:
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
 
-webpack-cli@^3.3.9:
+webpack-cli@3.3.9:
   version "3.3.9"
   resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.3.9.tgz#79c27e71f94b7fe324d594ab64a8e396b9daa91a"
   integrity sha512-xwnSxWl8nZtBl/AFJCOn9pG7s5CYUYdZxmmukv+fAHLcBIHM36dImfpQg3WfShZXeArkWlf6QRw24Klcsv8a5A==
@@ -4061,7 +4061,7 @@ webpack-sources@^1.4.0, webpack-sources@^1.4.1:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@^4.41.1:
+webpack@4.41.1:
   version "4.41.1"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.41.1.tgz#5388dd3047d680d5d382a84249fd4750e87372fd"
   integrity sha512-ak7u4tUu/U63sCVxA571IuPZO/Q0pZ9cEXKg+R/woxkDzVovq57uB6L2Hlg/pC8LCU+TWpvtcYwsstivQwMJmw==


### PR DESCRIPTION
~~Realized that we had locked the versions of a lot of our deps. This PR updates the semver range so to allow for semver-minor upgrades and updates two deps that have had a new semver-patch version released.~~

~~The issue I found of webpack warning about missing `require.extensions` should be fixed in the next Prettier release! (see https://github.com/prettier/prettier/issues/6656 for more details).~~