### PR TITLE
Add parsers

### DIFF
--- a/extension/src/content/index.js
+++ b/extension/src/content/index.js
@@ -1,5 +1,8 @@
+import parserAngular from "prettier/parser-angular";
 import parserBabylon from "prettier/parser-babylon";
 import parserFlow from "prettier/parser-flow";
+import parserGlimmer from "prettier/parser-glimmer";
+import parserGraphql from "prettier/parser-graphql";
 import parserHtml from "prettier/parser-html";
 import parserMarkdown from "prettier/parser-markdown";
 import parserPostcss from "prettier/parser-postcss";
@@ -9,8 +12,11 @@ import prettier from "prettier/standalone";
 
 function init() {
   const prettierPlugins = [
+    parserAngular,
     parserBabylon,
     parserFlow,
+    parserGlimmer,
+    parserGraphql,
     parserHtml,
     parserMarkdown,
     parserPostcss,

--- a/package.json
+++ b/package.json
@@ -5,16 +5,16 @@
   "repository": "https://github.com/prettier/prettier-chrome-extension.git",
   "license": "MIT",
   "scripts": {
-    "start": "webpack --mode=development --watch ",
     "build": "webpack",
+    "fix": "yarn fix:js && yarn fix:other",
     "fix:other": "yarn prettier --write",
     "fix:js": "yarn test:js --fix",
-    "fix": "yarn fix:js && yarn fix:other",
     "install": "yarn build",
     "prettier": "prettier \"**/*.{md,css,html,json,yml}\" --write",
+    "start": "webpack --mode=development --watch ",
+    "test": "yarn test:other && yarn test:js",
     "test:other": "yarn prettier --list-different",
-    "test:js": "eslint --ignore-path .gitignore --ignore-path .prettierignore \"**/*.js\"",
-    "test": "yarn test:other && yarn test:js"
+    "test:js": "eslint --ignore-path .gitignore --ignore-path .prettierignore \"**/*.js\""
   },
   "dependencies": {
     "prettier": "1.18.2"


### PR DESCRIPTION
This PR adds back the removed parsers that @nickmccurdy correctly [pointed out](https://github.com/prettier/prettier-chrome-extension/pull/36#discussion_r335286791) are still needed by the GitHub formatter.