### PR TITLE
Fix issue where github prettier button doesn't appear after new comment

### DIFF
--- a/extension/src/content/index.js
+++ b/extension/src/content/index.js
@@ -419,6 +419,7 @@ function init() {
       const newCommentObserver = new MutationObserver(() => {
         commentObserver.disconnect();
         setupCommentObserver(commentObserver);
+        initGitHubButton();
       });
       const pageObserver = new MutationObserver(() => {
         if (window.location.pathname !== currentPath) {


### PR DESCRIPTION
Fixes #51 
Simple fix that runs the initGithubButton() on change of the 'js-discussion' element (which contains all of the comments on a page)