### PR TITLE
Make options page a popup

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -9,7 +9,10 @@
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
   },
-  "options_page": "src/options/index.html",
+  "options_ui": {
+    "page": "src/options/index.html",
+    "open_in_tab": false
+  },
   "permissions": ["storage"],
   "content_scripts": [
     {

--- a/extension/src/options/index.html
+++ b/extension/src/options/index.html
@@ -7,6 +7,11 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
+    <!--
+      Chrome throws an error when checking for the height of the popup
+      if there aren't any elements on the page.
+    -->
+    <h1 class="chrome-options-spacer">Prettier Options</h1>
     <div id="root"></div>
     <script src="../../dist/options.js"></script>
   </body>

--- a/extension/src/options/index.js
+++ b/extension/src/options/index.js
@@ -22,6 +22,19 @@ function App() {
     });
   }, []);
 
+  /*
+   * Chrome throws an error when checking for the height of the popup if there aren't
+   * any elements on the page. We can use requestAnimationFrame() to ensure
+   * that the app's first paint has occurred.
+   */
+  useEffect(() => {
+    const spacerEl = document.querySelector(".chrome-options-spacer");
+
+    if (spacerEl) {
+      window.requestAnimationFrame(() => spacerEl.remove());
+    }
+  }, []);
+
   useEffect(() => {
     chrome.storage.sync.set({ options });
   }, [options]);


### PR DESCRIPTION
The reason we were having issues with this is that there's a script on the Chrome Extension settings page that checks the height of the popup HTML. The check occurs before React has rendered the application, and it throws as a result.

This PR adds a spacer element that is then removed on the first render. It's a bit hacky, but it works!