### PR TITLE
Move heading to HTML for popup

### DIFF
--- a/extension/src/options/index.html
+++ b/extension/src/options/index.html
@@ -2,13 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Prettier Options</title>
     <link rel="stylesheet" href="options.css" />
   </head>
   <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
     <h1>
-      <a href="https://prettier.io/docs/en/options.html">Prettier Options</a>
+      <a href="https://prettier.io/docs/en/options.html">Options</a>
     </h1>
     <div id="root"></div>
     <script src="options.js"></script>

--- a/extension/src/options/index.html
+++ b/extension/src/options/index.html
@@ -7,11 +7,9 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <!--
-      Chrome throws an error when checking for the height of the popup
-      if there aren't any elements on the page.
-    -->
-    <h1 class="chrome-options-spacer">Prettier Options</h1>
+    <h1>
+      <a href="https://prettier.io/docs/en/options.html">Prettier Options</a>
+    </h1>
     <div id="root"></div>
     <script src="options.js"></script>
   </body>

--- a/extension/src/options/index.js
+++ b/extension/src/options/index.js
@@ -22,19 +22,6 @@ function App() {
     });
   }, []);
 
-  /*
-   * Chrome throws an error when checking for the height of the popup if there aren't
-   * any elements on the page. We can use requestAnimationFrame() to ensure
-   * that the app's first paint has occurred.
-   */
-  useEffect(() => {
-    const spacerEl = document.querySelector(".chrome-options-spacer");
-
-    if (spacerEl) {
-      window.requestAnimationFrame(() => spacerEl.remove());
-    }
-  }, []);
-
   useEffect(() => {
     chrome.storage.sync.set({ options });
   }, [options]);
@@ -54,9 +41,6 @@ function App() {
   // Form based on https://github.com/codesandbox/codesandbox-client/blob/master/packages/app/src/app/pages/common/Modals/PreferencesModal/CodeFormatting/Prettier/index.tsx
   return options ? (
     <>
-      <h1>
-        <a href="https://prettier.io/docs/en/options.html">Prettier Options</a>
-      </h1>
       <hr />
       <label>Print width</label>
       <input


### PR DESCRIPTION
This is a different way to fix the layout bug fixed in #61. Instead of adding an extra spacer element, it moves the heading element (which we need to display anyway) to the HTML file. I also replaced `Prettier Options` with just `Options`, as the extension name `Prettier` is already displayed above.