### PR TITLE
Rename dist to extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
-dist
+extension
 extension.zip

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,1 @@
-dist
+extension

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ yarn react-devtools
 
 - Chrome Settings > More Tools > Extensions...
 - Turn on Developer mode
-- Load unpacked > Select the `dist` directory
+- Load unpacked > Select the `extension` directory
 
 ### Format files
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "yarn test:other && yarn test:js",
     "test:other": "yarn prettier --list-different",
     "test:js": "eslint --ignore-path .gitignore --ignore-path .prettierignore \"**/*.js\"",
-    "zip": "jszip-cli add -i .DS_Store -o extension.zip -f dist/*"
+    "zip": "jszip-cli add -i .DS_Store -o extension.zip -f extension/*"
   },
   "dependencies": {
     "copy-webpack-plugin": "5.0.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,7 +38,7 @@ module.exports = (env, argv) => ({
     ]
   },
   output: {
-    path: path.resolve(__dirname, "dist")
+    path: path.resolve(__dirname, "extension")
   },
   performance: {
     hints: false


### PR DESCRIPTION
Now we can continue to install the extension via the `extension` directory as discussed in https://github.com/prettier/prettier-chrome-extension/pull/71#discussion_r341822602.