### PR TITLE
Fix Create pull request button position

### DIFF
--- a/src/content/button.js
+++ b/src/content/button.js
@@ -1,9 +1,8 @@
-const COMMENT = "Comment";
-const REPLY = "Reply…";
 const CANCEL = "Cancel";
 const CLOSE_ISSUE = " Close issue";
 const CLOSE_PULL_REQUEST = " Close pull request";
-const SUBMIT_PULL_REQUEST = "Create pull request";
+const COMMENT = "Comment";
+const CREATE_PULL_REQUEST = "Create pull request";
 const SUBMIT_NEW_ISSUE = "Submit new issue";
 
 export const BUTTONS = {
@@ -11,17 +10,16 @@ export const BUTTONS = {
   CLOSE_ISSUE,
   CLOSE_PULL_REQUEST,
   COMMENT,
-  REPLY,
-  SUBMIT_NEW_ISSUE,
-  SUBMIT_PULL_REQUEST
+  CREATE_PULL_REQUEST,
+  SUBMIT_NEW_ISSUE
 };
 
 export const BUTTONS_TO_SEARCH_FOR = [
-  COMMENT,
   CANCEL,
   CLOSE_ISSUE,
   CLOSE_PULL_REQUEST,
-  SUBMIT_PULL_REQUEST,
+  COMMENT,
+  CREATE_PULL_REQUEST,
   SUBMIT_NEW_ISSUE
 ];
 

--- a/src/content/github.js
+++ b/src/content/github.js
@@ -81,12 +81,29 @@ export default class GitHub {
         continue;
       }
 
-      const prettierButton = renderButton(parentNode, {
+      const options = {
         append: true,
         classes: ["prettier-btn"],
-        refNode: button.innerText === BUTTONS.SUBMIT_NEW_ISSUE ? button : null,
+        refNode: null,
         style: { "margin-right": "4px" }
-      });
+      };
+
+      // These two buttons have a unique DOM structure, so we need
+      // to render the button relative to the left-most button.
+      if (
+        button.innerText === BUTTONS.SUBMIT_NEW_ISSUE ||
+        button.innerText === BUTTONS.CREATE_PULL_REQUEST
+      ) {
+        options.refNode = button;
+      }
+
+      // The Create pull request button has `float: left;`,
+      // causing issues with the flow of the button row.
+      if (button.innerText === BUTTONS.CREATE_PULL_REQUEST) {
+        options.style = { ...options.style, float: "left" };
+      }
+
+      const prettierButton = renderButton(parentNode, options);
       const inputEl = findWithClass(prettierButton, "comment-form-textarea");
 
       prettierButton.addEventListener("click", event => {


### PR DESCRIPTION
The Create pull request button is currently not displaying correctly:
<img width="397" alt="Screen Shot 2019-11-03 at 1 49 36 AM" src="https://user-images.githubusercontent.com/7041728/68080969-4db74680-fddc-11e9-83f8-bce6378a077c.png">

This is because the button has `float: left;` set, breaking the flow of the buttons.

With this PR, it's fixed to:

<img width="455" alt="Screen Shot 2019-11-03 at 1 48 29 AM" src="https://user-images.githubusercontent.com/7041728/68080970-4db74680-fddc-11e9-8508-1571bb343f93.png">
