### PR TITLE
Split up configs

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,4 @@
 {
-  "presets": ["@babel/preset-react"],
   "env": {
     "test": {
       "plugins": ["@babel/plugin-transform-modules-commonjs"]

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,9 @@
 {
+  "env": {
+    "es2020": true
+  },
   "plugins": ["prettier"],
   "extends": ["prettier"],
-  "parserOptions": {
-    "ecmaVersion": 2020
-  },
   "rules": {
     "curly": "error",
     "dot-notation": "error",
@@ -20,6 +20,7 @@
       }
     ],
     "no-shadow": "error",
+    "no-undef": "error",
     "no-unneeded-ternary": "error",
     "no-unused-expressions": "error",
     "no-unused-vars": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,12 +1,8 @@
 {
-  "env": {
-    "node": true
-  },
   "plugins": ["prettier"],
   "extends": ["prettier"],
   "parserOptions": {
-    "ecmaVersion": 2020,
-    "sourceType": "module"
+    "ecmaVersion": 2020
   },
   "rules": {
     "curly": "error",
@@ -50,25 +46,5 @@
     ],
     "sort-vars": "error",
     "strict": ["error", "global"]
-  },
-  "overrides": [
-    {
-      "files": ["src/**/*"],
-      "plugins": ["react-hooks"],
-      "extends": ["plugin:react/recommended"],
-      "env": {
-        "browser": true,
-        "node": false
-      },
-      "settings": {
-        "react": {
-          "version": "detect"
-        }
-      },
-      "rules": {
-        "react-hooks/rules-of-hooks": "error",
-        "react-hooks/exhaustive-deps": "error"
-      }
-    }
-  ]
+  }
 }

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "parserOptions": {
+    "sourceType": "module"
+  }
+}

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -1,4 +1,8 @@
 {
+  "env": {
+    "browser": true,
+    "webextensions": true
+  },
   "parserOptions": {
     "sourceType": "module"
   }

--- a/src/options/.babelrc
+++ b/src/options/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-react"]
+}

--- a/src/options/.eslintrc.json
+++ b/src/options/.eslintrc.json
@@ -1,0 +1,13 @@
+{
+  "plugins": ["react-hooks"],
+  "extends": ["plugin:react/recommended"],
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  },
+  "rules": {
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "error"
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+/* eslint-env node */
 "use strict";
 const path = require("path");
 const TerserPlugin = require("terser-webpack-plugin"); // included as a dependency of webpack

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+"use strict";
 const path = require("path");
 const TerserPlugin = require("terser-webpack-plugin"); // included as a dependency of webpack
 const CopyPlugin = require("copy-webpack-plugin");


### PR DESCRIPTION
- ~~I removed the env configs since they don't seem to be in use. If we want to use them I can enable the `no-undef` rule.~~
- Both ESLint and Babel configs are split up by directory.
- Babel is technically only needed for `src/options` but has an empty config elsewhere in case we add options outside this directory in the future.
- We can add overrides for things like tests as needed.