### PR TITLE
Fixes for "Split up configs"

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,5 @@
 {
+  "presets": ["@babel/preset-react"],
   "env": {
     "test": {
       "plugins": ["@babel/plugin-transform-modules-commonjs"]

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -47,5 +47,13 @@
     ],
     "sort-vars": "error",
     "strict": ["error", "global"]
-  }
+  },
+  "overrides": [
+    {
+      "files": "*test*.js",
+      "env": {
+        "jest": true
+      }
+    }
+  ]
 }

--- a/src/options/.babelrc
+++ b/src/options/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-react"]
-}


### PR DESCRIPTION
I noticed some problems with #88 after merging it into other branches:
- Babel replaces multiple configs (while ESLint merges them), so adding the second config to `src/options` breaks the Babel config in Jest tests outside `src/options`
- I forgot to add Jest's environment to ESLint after enabling `no-undef`