### PR TITLE
Add LeetCode support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,11 @@
   "permissions": ["storage"],
   "content_scripts": [
     {
-      "matches": ["https://stackoverflow.com/*", "https://github.com/*"],
+      "matches": [
+        "https://stackoverflow.com/*",
+        "https://github.com/*",
+        "https://leetcode.com/*"
+      ],
       "js": ["content.js"],
       "run_at": "document_end"
     }

--- a/src/content/extension.js
+++ b/src/content/extension.js
@@ -1,10 +1,13 @@
 import GitHub from "./github";
+import LeetCode from "./leetCode";
 import StackOverflow from "./stackOverflow";
 import Storage from "./storage";
 
 const GITHUB_URL = "https://github.com";
 const STACKOVERFLOW_URL = "https://stackoverflow.com";
 const STACKOVERFLOW_VALID_PATHNAMES = /(^\/questions|\/posts\/\d+\/edit)/u;
+const LEETCODE_URL = "https://leetcode.com";
+const LEETCODE_VALID_PATHNAMES = /(^\/problems)/u;
 
 export default class Extension {
   constructor() {
@@ -24,6 +27,13 @@ export default class Extension {
       STACKOVERFLOW_VALID_PATHNAMES.test(window.location.pathname)
     ) {
       this._buttons = new StackOverflow(this._storage);
+    }
+
+    if (
+      window.location.origin === LEETCODE_URL &&
+      LEETCODE_VALID_PATHNAMES.test(window.location.pathname)
+    ) {
+      this._buttons = new LeetCode(this._storage);
     }
   }
 }

--- a/src/content/leetCode.js
+++ b/src/content/leetCode.js
@@ -11,8 +11,8 @@ export default class LeetCode {
   _init() {
     this._addClientListeners();
 
-    this._createButton();
-    const pageObserver = new MutationObserver(() => this._createButton());
+    this._handleChange();
+    const pageObserver = new MutationObserver(() => this._handleChange());
     pageObserver.observe(document.querySelector("body"), {
       childList: true,
       subtree: true
@@ -52,6 +52,19 @@ export default class LeetCode {
     script.remove();
   }
 
+  _handleChange() {
+    const languageEl = document.querySelector('[data-cy="lang-select"]');
+    if (!languageEl) {
+      return;
+    }
+
+    if (languageEl.innerText !== "JavaScript") {
+      this._removeButton();
+    } else {
+      this._createButton();
+    }
+  }
+
   _createButton() {
     const buttonRowEl = document.querySelector('[class^="btns"]');
     if (!buttonRowEl) {
@@ -82,6 +95,13 @@ export default class LeetCode {
       // Initiating format event chain
       document.dispatchEvent(new Event("GetEditorContent"));
     });
+  }
+
+  _removeButton() {
+    const button = document.querySelector(".prettier-btn");
+    if (button) {
+      button.remove();
+    }
   }
 
   _addExtensionListener() {

--- a/src/content/leetCode.js
+++ b/src/content/leetCode.js
@@ -64,9 +64,18 @@ export default class LeetCode {
       }
     }
 
+    // Using styles from existing language select element
+    const selectEl = document.querySelector('[data-cy="lang-select"]')
+      .parentElement;
+    const selectClasses = [...selectEl.classList];
+
     renderButton(buttonRowEl, {
-      classes: ["prettier-btn", "btn__1eiM", "btn-xs__2rgD"],
-      style: { margin: "0 10px" }
+      classes: ["prettier-btn", ...selectClasses],
+      style: {
+        cursor: "pointer",
+        margin: "0 10px",
+        padding: "0 10px"
+      }
     }).addEventListener("click", event => {
       event.preventDefault();
 

--- a/src/content/leetCode.js
+++ b/src/content/leetCode.js
@@ -15,7 +15,7 @@ export default class LeetCode {
     const pageObserver = new MutationObserver(() => this._handleChange());
     pageObserver.observe(document.querySelector("body"), {
       childList: true,
-      subtree: true
+      subtree: true,
     });
 
     this._addExtensionListener();
@@ -35,7 +35,7 @@ export default class LeetCode {
         }
       });
 
-      document.addEventListener("SetEditorContent", event => {
+      document.addEventListener("SetEditorContent", (event) => {
         const editor = document.querySelector(".CodeMirror");
         if (editor) {
           editor.CodeMirror.doc.setValue(event.detail);
@@ -87,9 +87,9 @@ export default class LeetCode {
       style: {
         cursor: "pointer",
         margin: "0 10px",
-        padding: "0 10px"
-      }
-    }).addEventListener("click", event => {
+        padding: "0 10px",
+      },
+    }).addEventListener("click", (event) => {
       event.preventDefault();
 
       // Initiating format event chain
@@ -105,13 +105,13 @@ export default class LeetCode {
   }
 
   _addExtensionListener() {
-    document.addEventListener("FormatEditorContent", event => {
+    document.addEventListener("FormatEditorContent", (event) => {
       const snippet = event.detail;
 
       const formattedSnippet = prettier.format(snippet, {
         parser: PARSERS_LANG_MAP.js,
         plugins: PARSERS,
-        ...this._getOptions()
+        ...this._getOptions(),
       });
 
       document.dispatchEvent(


### PR DESCRIPTION
Hi all! I've been using LeetCode (popular coding interview prep site) recently and really wished I could add Prettier integration to their site's editor. After talking with @nickmccurdy, he introduced me to this awesome project and I realized I could just contribute to this rather than make my own extension.

LeetCode uses a library called [CodeMirror](https://codemirror.net/) for their integrated editor (specifically, [react-codemirror2](https://github.com/scniro/react-codemirror2)). Though it's fairly tricky to get / set the editor's content by inspecting the DOM alone, the editor's CodeMirror instance is exposed as a property of the editor DOM element (`.CodeMirror`). This makes it super easy to call CodeMirror methods:

```js
const editor = document.querySelector(".CodeMirror");
// Get the editor's content
editor.CodeMirror.doc.getValue();
// Set the editor's content
editor.CodeMirror.doc.setValue('some code');
```

Unfortunately, this property is only accessible within a page context - as extension content scripts are sandboxed, this CodeMirror instance can't be used in the same way. To get around this, I've created some helper methods that are injected into the page context to get / set the editor's content (see `_addClientListeners`).

Right now, this implementation works, though there are some things I'm not crazy about:

- I'm currently injecting the client script by creating a script element, setting its `textContent` through a template literal, and injecting that into the DOM. [This StackOverflow post](https://stackoverflow.com/questions/9515704/insert-code-into-the-page-context-using-a-content-script/9517879#9517879) nicely summarizes some other possible ways to run code within a page context - I'm open to other methods.
- Event listener hell. Right now the flow is "GetEditorContent" -> "FormatEditorContent" -> "SetEditorContent", but this isn't super easy to follow. I'm not sure what a better way to handle client-extension communication would be.
- Right now this implementation assumes the editor is set to JavaScript. I think this is the only language we could support right now with the current parser setup (unless we add community plugins, but that's another conversation), but we should probably remove the Prettier button when the editor language is set to something other than JavaScript.
- I'm not super familiar with MutationObserver and mostly just copied the StackOverflow implementation. I'm pretty sure there's a more specific query to observe than `body` and I might not need the `childList` and `subtree` options - open to optimizations there.
- I'm manually grabbing class names for button styling, but they seem to be auto-generated classes that might not stay constant with new LeetCode changes. Ideally, I'd like to either apply those styles manually or find a more consistent way of grabbing them from LeetCode.

I'm leaving this as a draft PR as I think it still needs some more work before being merged. Very open to any thoughts you guys may have!
