### PR TITLE
Enable chrome styled input elements

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -11,7 +11,8 @@
   },
   "options_ui": {
     "page": "options.html",
-    "open_in_tab": false
+    "open_in_tab": false,
+    "chrome_style": true
   },
   "permissions": ["storage"],
   "content_scripts": [

--- a/src/options/JsonConfig.js
+++ b/src/options/JsonConfig.js
@@ -67,6 +67,7 @@ export default function JsonConfig({ errors, options, setErrors, setOptions }) {
         value={textAreaVal}
         ref={textareaEl}
         onChange={handleChange}
+        spellCheck="false"
       />
       <button onClick={handleClick}>Save</button>
       {displaySaved && <span className="saved">Saved</span>}


### PR DESCRIPTION
- Enable chrome styled input elements, so that it will look consistent across platform in chromium based browsers
- disable spell check in json config editor

**Before:**

<img width="425" alt="Screenshot 2020-07-27 at 11 04 21 AM" src="https://user-images.githubusercontent.com/20282546/88507719-a8dc3980-cffa-11ea-9da5-b497b4d29c6e.png">


**After**

<img width="419" alt="Screenshot 2020-07-27 at 11 04 42 AM" src="https://user-images.githubusercontent.com/20282546/88507736-b5609200-cffa-11ea-86dc-a57cf9c3f094.png">