### PR TITLE
Grab manifest version from package.json

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,5 @@
 {
   "name": "Prettier",
-  "version": "0.0.5",
   "manifest_version": 2,
   "description": "Prettier all the things.",
   "homepage_url": "https://prettier.io",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,8 @@ const HTMLPlugin = require("html-webpack-plugin");
 const webpack = require("webpack");
 const MergeJsonPlugin = require("merge-json-webpack-plugin");
 
+const { version } = require("./package.json");
+
 const isFirefox = process.env.PLATFORM === "firefox";
 
 module.exports = ({ outDir, env }) => {
@@ -81,6 +83,7 @@ module.exports = ({ outDir, env }) => {
       new MergeJsonPlugin({
         group: [
           {
+            beforeEmit: (manifest) => ({ version, ...manifest }),
             files: [
               "src/manifest.json",
               isFirefox && "src/firefox-manifest.json",


### PR DESCRIPTION
Hi all 👋 this PR is just a quality of life change to prevent having to maintain two versions in `package.json` and `src/manifest.json`. merge-json-webpack-plugin exposes a handy property `beforeEmit` that I used to put the `package.json` version into the final manifest.